### PR TITLE
add backup Salinity SOP link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@ A good start is also to [introduce you](https://github.com/OceanGlidersCommunity
 - Access and discuss the new [OceanGliders format](https://github.com/OceanGlidersCommunity/OG1.0-user-manual).
 - SOPs for Data Assembly Centers are available [here](https://github.com/OceanGlidersCommunity/DataAssemblyCenter_SOP).
 - Join the [Oxygen SOP](https://oceangliderscommunity.github.io/Oxygen_SOP/README.html#). v1.0.0 released on June 1 2022, [doi](http://dx.doi.org/10.25607/OBP-1756)
-- Join the [Salinity SOP](https://oceangliderscommunity.github.io/Salinity_SOP/README.html#) community review: Open until June 30 2022. 
+- Join the [Salinity SOP](https://oceangliderscommunity.github.io/Salinity_SOP/README.html#) community review: Open until June 30 2022. ([Backup link to SOP](https://62b2368a376f89375b1c03c1--salinitysop.netlify.app/readme) until the official one is fixed!) 
 - Join the [Nitrate SOP](https://oceangliderscommunity.github.io/Nitrate_SOP/README.html#) community review: Open until June 30 2022. 
 - Join the [Depth Average Currents (DACs) SOP](https://oceangliderscommunity.github.io/DepthAverageCurrents_SOP/README.html).
 


### PR DESCRIPTION
I just link to the last Netlify Test Deployment so that we have one working Jupyter Notebook until the other one is fixed during the workshop!

@vturpin 
This is an ugly work around for #7